### PR TITLE
Fix for overflow dropdown hidden

### DIFF
--- a/jekyll/assets/css/theme.css
+++ b/jekyll/assets/css/theme.css
@@ -2,7 +2,7 @@
  * Mundana Jekyll Theme (https://www.wowthemes.net/mundana-jekyll-theme/)
  */
 
-body {
+ body {
 	overflow-x:hidden;
 	padding-top:69.75px;
 }
@@ -189,6 +189,7 @@ a.text-dark:hover {
 }
 .navbar {
 	transition:top 0.2s ease-in-out;
+	z-index: 999;
 	font-weight:400;
 }
 .navbar .highlight .nav-link {
@@ -213,6 +214,8 @@ a.text-dark:hover {
 .dropdown-menu {
 	border:0;
 	text-transform:none;
+	overflow: visible;
+	z-index: 1000;
 	box-shadow:0 10px 25px 0 rgba(0,0,0,0.3);
 }
 @media (min-width:768px) {


### PR DESCRIPTION
I have added a `z-index` to the `dropdown-menu` class, this may fix the overflow menu hidden issue, but it will only be understandable after being deployed as we are unable to reproduce it locally.

Refer: #883 