### PR TITLE
Update tutorials running locally page

### DIFF
--- a/docusaurus/docs/getting-started/running-locally.mdx
+++ b/docusaurus/docs/getting-started/running-locally.mdx
@@ -178,7 +178,7 @@ You are ready to play with the bot.
 
 Let's get started with building the Ding Dong bot using Wechaty.
 
-### 1. Initialise project
+### 1. Initialize project
 
 Create a new folder called `ding-dong-bot` and move into that directory.
 
@@ -339,7 +339,7 @@ async function onMessage (msg: Message) {
 }
 ```
 
-Now initialising the bot by providing a name.
+Now initializing the bot by providing a name.
 
 ```ts
 const bot = new Wechaty({

--- a/docusaurus/docs/getting-started/running-locally.mdx
+++ b/docusaurus/docs/getting-started/running-locally.mdx
@@ -187,6 +187,29 @@ mkdir ding-dong-bot
 cd ding-dong-bot
 ```
 
+Use the following command to initialize an npm project:
+
+```bash
+npm init -y
+```
+
+This will generate the `package.json` file containing these:
+
+```json
+{
+  "name": "ding-dong-bot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}
+```
+
 ### 2. Install dependencies
 
 For building the ding dong bot you will require these dependencies:


### PR DESCRIPTION
The current **Running locally** page under Tutorials is missing an important command without which the NPM project won't be initialized and none of the dependencies can be installed.

Have added the `npm init -y` command before installing dependencies. (this was present in PR #888 earlier but I think after the last change before merging it got removed by mistake).

## Before:

<img width="854" alt="Screenshot 2021-07-10 at 8 10 17 AM" src="https://user-images.githubusercontent.com/43280874/125149374-5e45c580-e156-11eb-9b9b-7146b1df02d9.png">


## After

<img width="857" alt="Screenshot 2021-07-10 at 8 09 39 AM" src="https://user-images.githubusercontent.com/43280874/125149377-630a7980-e156-11eb-965f-fb08894d9e37.png">

Tag #891 
