### PR TITLE
Change the value of href attribute for 'Edit this page' hypertext

### DIFF
--- a/docusaurus/config/presets/preset-classic.js
+++ b/docusaurus/config/presets/preset-classic.js
@@ -9,7 +9,7 @@
   {
     docs: {
       sidebarPath: require.resolve('../../sidebars.ts'),
-      editUrl: 'https://github.com/wechaty/wechaty.js.org/edit/master/docusaurus/',
+      editUrl: 'https://github.com/wechaty/wechaty.js.org/edit/main/docusaurus/',
       showLastUpdateAuthor: true,
       showLastUpdateTime: true,
     },


### PR DESCRIPTION
Currently when you navigate to any page on [wechaty.js.org](https://wechaty.js.org/docs/) page, clicking `Edit this page` hyperlink at the bottom will open to a non-existent page. You will see a 404 page doesn't exist text. This is  because the hyperlink text is still pointing to the master branch which has been renamed to main.  This PR changes it to point to the main branch.

Closes #1334 