### PR TITLE
upgrade docusaurus to version 2.2

### DIFF
--- a/docusaurus/docs/community/overview.mdx
+++ b/docusaurus/docs/community/overview.mdx
@@ -7,10 +7,10 @@ Here you can find some of our great community events.
 
 ## Table of contents
 
-- [BOT Friday Club](./bot5/overview.md)
-- [Open Source Promotion Plan](./ospp/overview.md)
-- [Google Summer of Code](./gsoc/overview.md)
-- [Google Season of Docs](./gsod/overview.md)
+- [BOT Friday Club](../bot5/overview.md)
+- [Open Source Promotion Plan](../ospp/overview.md)
+- [Google Summer of Code](../gsoc/overview.md)
+- [Google Season of Docs](../gsod/overview.md)
 
 ## Contributors profile list
 

--- a/docusaurus/docs/examples/basic/ding-dong-bot.md
+++ b/docusaurus/docs/examples/basic/ding-dong-bot.md
@@ -23,7 +23,7 @@ Just scan the generated QR code with **WeChat** app, and you are ready to play w
 
 ## Building the bot
 
-If you want to run `ding-dong bot` locally and build it from scratch you can refer [here](../docs/getting-started/running-locally.mdx).
+If you want to run `ding-dong bot` locally and build it from scratch you can refer [here](../../getting-started/running-locally.mdx).
 
 ## Bot demonstration
 

--- a/docusaurus/docs/tutorials/installation.md
+++ b/docusaurus/docs/tutorials/installation.md
@@ -78,7 +78,7 @@ Wechaty Puppet Providers are **npm** packages that you can install by using the 
 npm install wechaty-puppet-NAME
 ```
 
-> You have to replace the `wechaty-puppet-NAME` with the puppet you want to use. There are various puppets available, you can choose from [here](./puppet-providers/overview.mdx).
+> You have to replace the `wechaty-puppet-NAME` with the puppet you want to use. There are various puppets available, you can choose from [here](../puppet-providers/overview.mdx).
 
 ## Good to go
 

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -15,8 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.18",
-    "@docusaurus/preset-classic": "2.0.0-beta.18",
+    "@docusaurus/core": "^2.2.0",
+    "@docusaurus/preset-classic": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
@@ -28,8 +28,8 @@
     "redocusaurus": "^1.0.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.0.0-beta.18",
-    "@docusaurus/plugin-pwa": "^2.0.0-beta.18",
+    "@docusaurus/module-type-aliases": "^2.2.0",
+    "@docusaurus/plugin-pwa": "^2.2.0",
     "@ionic-internal/docusaurus-plugin-tag-manager": "github:ionic-team/docusaurus-plugin-tag-manager",
     "@tsconfig/docusaurus": "^1.0.5",
     "@types/react": "^17.0.43",


### PR DESCRIPTION
Docusaurus 2.2 is officially published, so we should started using v2.2 instead of v2.0-beta of docusaurus.

This PR also fixed some issues that break the build