### PR TITLE
docs: added contributors profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,12 @@ At the same time, we also meet up offline all over the world. Here are some acti
 - [Markdown Linting Rules Documents](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md)
 
 ## Writers
+<a href="https://github.com/wechaty/docusaurus/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=wechaty/docusaurus" />
+</a>
 
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/0)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/0)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/1)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/1)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/2)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/2)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/3)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/3)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/4)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/4)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/5)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/5)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/6)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/6)
-[![contributor](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/images/7)](https://sourcerer.io/fame/huan/wechaty/wechaty.js.org/links/7)
 
-To get to know all our writers, see <https://github.com/wechaty/wechaty.js.org/graphs/contributors>
+> To get to know all our writers, see <https://github.com/wechaty/wechaty.js.org/graphs/contributors>
 
 ## History
 


### PR DESCRIPTION
Added all contributor's profile images by adding contrib.rocks website's link. It will automatically add the new contributor's image when a new user's pr will get merged.

solved #1516


#### Screenshots

![Screenshot from 2023-04-05 23-38-54](https://user-images.githubusercontent.com/88102392/230167448-27bf7a74-f71b-4fc3-aafd-2736cf77abc7.png)
