### PR TITLE
add new intro video to homepage

### DIFF
--- a/.file-name-linter.json
+++ b/.file-name-linter.json
@@ -6,7 +6,7 @@
     ],
     "docusaurus/static": [
       "^(\\.?)[0-9\\-a-z_]+(\\.?)",
-      "\\.(webp|pdf|zip|svg|css|ico|png|nojekyll|js|json)$"
+      "\\.(webp|pdf|zip|svg|css|ico|png|nojekyll|js|json|mp4)$"
     ]
   },
   "ignore": [

--- a/docusaurus/src/pages/features-section/features-section.css
+++ b/docusaurus/src/pages/features-section/features-section.css
@@ -140,6 +140,11 @@
   margin-top: -5px;
 }
 
+#video {
+  width: 620px;
+  height: 380px;
+}
+
 #featuresSectionLowerWrapper {
   background-color: var(--ifm-hero-background-color);
   border-radius: 150px;
@@ -443,6 +448,11 @@
     margin-bottom: 50px;
   }
 
+  #videoPlaceholder {
+    width: 350px;
+    height: 200px;
+  }
+
   #featuresSectionLowerWrapper {
     border-radius: 70px;
   }
@@ -565,6 +575,11 @@
     width: 420px;
     height: 250px;
     margin-right: 40px;
+  }
+
+  #videoPlaceholder {
+    width: 420px;
+    height: 250px;
   }
 
   #featuresText {

--- a/docusaurus/src/pages/features-section/features-section.tsx
+++ b/docusaurus/src/pages/features-section/features-section.tsx
@@ -86,7 +86,13 @@ const FeaturesSection = () => {
             <p id="featuresListing">Multi-platform support.</p>
             <p id="featuresListing">Friendship managment.</p>
           </div>
-          <div id="videoPlaceholder" />
+          <div id="videoPlaceholder">
+            <video controls
+              id="video"
+              src="img/introduction-video.mp4" 
+              type="video/mp4"
+            />
+          </div>
         </div>
         <div id="featuresSectionLowerWrapper">
           <div id="featuresNumberWrapper">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-docusaurus",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Wechaty Official Website for Documentations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This PR adds the new and improved Wechaty intro video onto the homepage! The video is embedded as a local mp4.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dadee9d76c830eb42ccc87b9e4a442e0bc0c9379  | 
|--------|--------|

### Summary:
Added a new intro video to the homepage by embedding a local mp4 file and updating the relevant styles.

**Key points**:
- Added new intro video to homepage in `docusaurus/src/pages/features-section/features-section.tsx`.
- Embedded video as local mp4 file `docusaurus/static/img/introduction-video.mp4`.
- Updated `docusaurus/src/pages/features-section/features-section.css` to style the video and its placeholder.
- Video added within `div` with id `videoPlaceholder` and styled with id `video`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a video element to the Features section for improved user interaction.

- **Style**
  - Adjusted the dimensions of video elements for better display across devices.

- **Chores**
  - Updated the version of "wechaty-docusaurus" from `0.11.7` to `0.11.8`.
  - Added `mp4` to the list of allowed file types for static files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->